### PR TITLE
Fixes kn6plv/meshchat#18 add missing tab in file listing when responding to local_files_raw

### DIFF
--- a/src/data/www/cgi-bin/meshchat
+++ b/src/data/www/cgi-bin/meshchat
@@ -352,7 +352,7 @@ function local_files_raw()
     for file in nixio.fs.dir(local_files_dir)
     do
         local stat = nixio.fs.stat(local_files_dir .. "/" .. file)
-        f:write(file .. "\t" .. name .. "\t" .. stat.size .. "\t" .. stat.mtime .. platform .. "\n")
+        f:write(file .. "\t" .. name .. "\t" .. stat.size .. "\t" .. stat.mtime .. "\t" .. platform .. "\n")
     end
     f:close()
 


### PR DESCRIPTION
There's a tab missing from the response to local_files_raw. This change puts that back in.

Before this change filesharing doesn't work as per #18. Files only show up locally, not on remote nodes.
I made this very small change locally on a node running meshchat 2.8 and suddenly files show up on remote nodes.